### PR TITLE
Update image, remove unused deps

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @famedly/workflows

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM docker.io/rust:bullseye
+FROM docker.io/rust:bookworm
 
-ARG NIGHTLY_VERSION=nightly-2023-09-10
+ARG NIGHTLY_VERSION=nightly-2024-06-17
 ENV NIGHTLY_VERSION=${NIGHTLY_VERSION}
 
 RUN apt update -yqq \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ ENV NIGHTLY_VERSION=${NIGHTLY_VERSION}
 RUN apt update -yqq \
      && apt install -yqq --no-install-recommends \
      build-essential cmake libssl-dev pkg-config git musl-tools jq xmlstarlet lcov protobuf-compiler libprotobuf-dev libprotoc-dev \
-     && rustup toolchain uninstall /usr/local/rustup/toolchains/* \
      && rustup toolchain add $NIGHTLY_VERSION --component rustfmt --component clippy --component llvm-tools-preview \
      && rustup toolchain add stable --component rustfmt --component clippy --component llvm-tools-preview \
      && rustup default stable \
@@ -15,8 +14,6 @@ RUN apt update -yqq \
      && cargo install cargo-llvm-cov \
      && cargo install cargo-deny \
      && cargo install sqlx-cli \
-     && cargo install --git https://github.com/paritytech/cachepot \
-     && cargo install --git https://github.com/FlixCoder/cargo-lints.git \
      && cargo install typos-cli \
      && cargo install conventional_commits_linter \
      && cargo install cargo-udeps --locked \
@@ -24,6 +21,6 @@ RUN apt update -yqq \
      && cargo install cargo-readme \
      && cargo install cargo-audit \
      && cargo install cargo-auditable \
-     && cargo install --git https://github.com/kate-shine/cargo-license.git --branch  shine/gitlab_license_scan --force # fix after it gets merged to upstream \
+     && cargo install cargo-license \
      && cargo cache -a
 COPY cobertura_transform.xslt /opt/


### PR DESCRIPTION
This removes some cargo tools we no longer need, as well as some patches that are now upstreamed. Additionally bumps the base image from `bullseye` to `bookworm`. Note that this removes `cargo-lints` - there may still be some places where we haven't moved the lints from a separate lints file into `Cargo.toml`, those projects will need to be updated before they can be built with this image.