### PR TITLE
fix: Add current date to make it possible to pin versions and add rust beta toolchain

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,7 +7,7 @@ name: Docker
 
 on:
   schedule:
-    - cron: '31 0 * * *'
+    - cron: '30 1 * * 1' # run every Monday at 01:30
   workflow_dispatch:
   push:
     branches: [ "main" ]
@@ -17,13 +17,24 @@ on:
     branches: [ "main" ]
 
 jobs:
+  set_date:
+    runs-on: ubuntu-latest
+    outputs:
+      date_today: ${{ steps.date_step.outputs.today }}
+    steps:
+      - id: date_step
+        run: echo "today=$(date +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
   docker:
+    needs: set_date
     uses: famedly/github-workflows/.github/workflows/docker.yml@49401388492ed7fe3eeb13fbefacf68168e9bc64
     with:
       push: ${{ github.event_name != 'pull_request' }} # Always build, don't publish on pull requests
       image_name: rust-container
       tags: |
         type=raw,value=nightly
+        type=raw,value=nightly-${{needs.set_date.outputs.date_today}}
+      build_args: |
+        NIGHTLY_VERSION_DATE=${{needs.set_date.outputs.date_today}}
       registry: docker-oss.nexus.famedly.de
       registry_user: ${{ vars.NEXUS_REGISTRY_USER }}
     secrets: inherit

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
 FROM docker.io/rust:bookworm
 
-ENV NIGHTLY_VERSION=nightly
+ARG NIGHTLY_VERSION_DATE
+ENV NIGHTLY_VERSION=nightly-$NIGHTLY_VERSION_DATE
 
 RUN apt update -yqq \
      && apt install -yqq --no-install-recommends \
      build-essential cmake libssl-dev pkg-config git musl-tools jq xmlstarlet lcov protobuf-compiler libprotobuf-dev libprotoc-dev \
      && rustup toolchain add $NIGHTLY_VERSION --component rustfmt --component clippy --component llvm-tools-preview \
+     && rustup toolchain add beta --component rustfmt --component clippy --component llvm-tools-preview \
      && rustup toolchain add stable --component rustfmt --component clippy --component llvm-tools-preview \
      && rustup default stable \
      && cargo install grcov \


### PR DESCRIPTION
- This adds a data again so it is possible to pin versions again and to see easily what nightly version was used
- Also adds rust beta toolchain. Just in case we want to switch to it instead of using nightly for clippy.