### PR TITLE
fix: Place the `push` key in the correct spot

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -48,7 +48,10 @@ jobs:
       push: true
       image_name: rust-container
       tags: |
-        type=raw,value=dev-${{ github.ref_name }}
+        type=ref,event=branch,prefix=dev-
+        type=ref,event=tag,prefix=dev-
+        type=raw,event=pr,value=dev-${{ github.head_ref }}
+        type=sha,prefix=dev-
       build_args: |
         NIGHTLY_VERSION_DATE=${{needs.set_date.outputs.date_today}}
       registry: docker-nightly.nexus.famedly.de

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -26,10 +26,10 @@ jobs:
 
   publish_release:
     if: github.event.pull_request.merged == true
-    push: true
     needs: set_date
     uses: famedly/github-workflows/.github/workflows/docker.yml@49401388492ed7fe3eeb13fbefacf68168e9bc64
     with:
+      push: true
       image_name: rust-container
       tags: |
         type=raw,value=nightly
@@ -42,10 +42,10 @@ jobs:
 
   publish_dev:
     if: github.event.pull_request.merged != true
-    push: true
     needs: set_date
     uses: famedly/github-workflows/.github/workflows/docker.yml@49401388492ed7fe3eeb13fbefacf68168e9bc64
     with:
+      push: true
       image_name: rust-container
       tags: |
         type=raw,value=dev-${{ github.ref_name }}


### PR DESCRIPTION
Sorry about all the confusion up until this, hard to work with GitHub actions if they're not running.

Finally working:

![image](https://github.com/user-attachments/assets/72dbe013-cacf-4a20-882f-eb9da99de321)