### PR TITLE
fix: add openssh-client to the debian packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN apt update -yqq && apt install -yqq --no-install-recommends \
      git \
      jq \
      lcov \
+     openssh-client \
      libprotobuf-dev \
      libprotoc-dev \
      libssl-dev \


### PR DESCRIPTION
This is necessary for running prepare-ssh script.

closes:  https://github.com/famedly/rust-container/issues/26