### PR TITLE
chore: update GitHub Action pins

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -70,7 +70,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772
+        uses: docker/login-action@2ff7bc63ffa51414f77e9cbeea0d3297c1672d2e
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -78,7 +78,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9
         with:
           images: ghcr.io/${{ github.repository_owner }}/rust-container
           tags: |
@@ -87,7 +87,7 @@ jobs:
             type=raw,value=latest
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
+        uses: docker/build-push-action@9e8d01178c767b734d2fef9a000ac2a2137f483f
         with:
           context: .
           push: true
@@ -108,7 +108,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772
+        uses: docker/login-action@2ff7bc63ffa51414f77e9cbeea0d3297c1672d2e
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -116,7 +116,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9
         with:
           images: ghcr.io/${{ github.repository_owner }}/rust-container
           tags: |
@@ -126,7 +126,7 @@ jobs:
             type=sha,prefix=dev-
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
+        uses: docker/build-push-action@9e8d01178c767b734d2fef9a000ac2a2137f483f
         with:
           context: .
           push: true

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -27,7 +27,7 @@ jobs:
   publish_release:
     if: github.ref == 'refs/heads/main'
     needs: set_date
-    uses: famedly/github-workflows/.github/workflows/docker.yml@main
+    uses: famedly/github-workflows/.github/workflows/docker.yml@57b383862ba81dfa265bb33d492e2bbcbc96891d
     with:
       push: true
       image_name: rust-container
@@ -43,7 +43,7 @@ jobs:
   publish_dev:
     if: github.ref != 'refs/heads/main'
     needs: set_date
-    uses: famedly/github-workflows/.github/workflows/docker.yml@main
+    uses: famedly/github-workflows/.github/workflows/docker.yml@57b383862ba81dfa265bb33d492e2bbcbc96891d
     with:
       push: true
       image_name: rust-container
@@ -67,7 +67,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@900f2210b1d28bbbd0bd22d17926b9e224e8f231
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@2ff7bc63ffa51414f77e9cbeea0d3297c1672d2e
@@ -105,7 +105,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@900f2210b1d28bbbd0bd22d17926b9e224e8f231
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@2ff7bc63ffa51414f77e9cbeea0d3297c1672d2e


### PR DESCRIPTION
## Summary
- Update GitHub Actions in workflows to the latest upstream default-branch commit SHAs.
- Keep existing action paths and only replace refs after `@`.

## Verification
- Checked generated diff to include only `.github/**/*.yml` / `.github/**/*.yaml` workflow action refs.
- CI on this PR should validate the updated action versions.